### PR TITLE
Refactor NuGet push command in test.yml for readability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,4 +56,5 @@ jobs:
     - name: Push to NuGet
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push ./nupkg/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: |
+        dotnet nuget push ./nupkg/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
The `run` command for pushing the NuGet package in the `test.yml` file has been updated from a single-line command to a multi-line command. This change improves the readability and maintainability of the YAML configuration file without altering its functionality.