### PR TITLE
Update NuGet push path in GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,4 +57,4 @@ jobs:
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
       run: |
-        dotnet nuget push ./nupkg/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate
+        dotnet nuget push src/EscPosCommand/nupkg/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
Changed the NuGet package push command in `test.yml` to use the `src/EscPosCommand/nupkg/` directory instead of `./nupkg/`. This ensures the correct packages are pushed to the NuGet repository.