### PR TITLE
Update path in `dotnet nuget push` command in `test.yml`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,4 +57,4 @@ jobs:
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
       run: |
-        dotnet nuget push ./nupkg/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate
+        dotnet nuget push ${{ github.workspace }}/nupkg/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
Changed the path in `dotnet nuget push` command from `./nupkg/*.nupkg` to `${{ github.workspace }}/nupkg/*.nupkg` in `test.yml` to ensure the command uses the full path within the GitHub Actions workspace, avoiding issues with relative paths.