### PR TITLE
Improve .NET workflow by explicitly locating .nupkg file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,13 @@ jobs:
     - name: Pack
       run: dotnet pack src/EscPosCommand/EscPosCommand.csproj --configuration Release --no-restore --output ./nupkg
       
+    - name: Find .nupkg file
+      id: nupkg-file
+      run: echo "nupkg_file=$(find ${{ github.workspace }}/nupkg -name '*.nupkg')" >> $GITHUB_ENV
+
     - name: Push to NuGet
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        NUPKG_FILE: ${{ env.nupkg_file }}
       run: |
-        dotnet nuget push ${{ github.workspace }}/nupkg/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate
+        dotnet nuget push $NUPKG_FILE --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
Modified the GitHub Actions workflow in `test.yml` to add a new step "Find .nupkg file" that locates the generated .nupkg file and stores its path in the `nupkg_file` environment variable. Updated the "Push to NuGet" step to use this environment variable, enhancing the reliability of the workflow by ensuring the correct .nupkg file is pushed to NuGet.